### PR TITLE
Add ESLint and tweak package.json

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,1 @@
+extends: fxa/server

--- a/package.json
+++ b/package.json
@@ -1,18 +1,23 @@
 {
   "name": "hapi-fxa-oauth",
+  "description": "A simple authentication plugin for Hapi applications to become Firefox Accounts OAuth service providers",
   "version": "2.0.1",
-  "description": "",
-  "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "author": "",
-  "license": "MPL 2.0",
+  "author": "Mozilla (https://mozilla.org/)",
   "dependencies": {
     "boom": "2.6.1",
     "poolee": "0.4.15"
   },
+  "devDependencies": {
+    "eslint": "^1.7.3",
+    "eslint-config-fxa": "^2.0.0"
+  },
+  "license": "MPL-2.0",
+  "main": "index.js",
   "peerDependencies": {
     "hapi": ">=8.x.x"
+  },
+  "scripts": {
+    "lint": "eslint .",
+    "test": "npm run lint"
   }
 }


### PR DESCRIPTION
Surprisingly, ESLint didn't complain that we don't have a radix specified in the `parseInt()` on [line 31](https://github.com/mozilla/hapi-fxa-oauth/blob/7017b98084fafe10a855404475644dbb391d3409/index.js#L31).

Also, not sure if we want to specify the `peerDependencies` in the package.json file. IIRC, those have been removed in **npm@3** and are no longer automatically installed. Which may not be so bad, since it seems to currently be installing **hapi@11.0.2** locally for me (which I believe requires **node@4+** -- per github.com/hapijs/hapi/issues/2764).

> npm WARN peerDependencies The peer dependency hapi included from hapi-fxa-oauth will no
> npm WARN peerDependencies longer be automatically installed to fulfill the peerDependency
> npm WARN peerDependencies in npm 3+. Your application will need to depend on it explicitly.
